### PR TITLE
Bugfix: predicate functions

### DIFF
--- a/Basemaps/municipalities.R
+++ b/Basemaps/municipalities.R
@@ -6,7 +6,7 @@ library(sf)
 municipalities <- here::here("Basemaps", "input", "SuomenKuntajako_2021_100k") %>%
   sf::read_sf(options = "ENCODING=ISO-8859-1") %>%
   sf::st_set_crs(3067) %>%
-  dplyr::mutate(across(is.character, ~iconv(.x, from = "ISO-8859-1", to = "UTF-8")))
+  dplyr::mutate(across(where(is.character), ~iconv(.x, from = "ISO-8859-1", to = "UTF-8")))
 
 hs15 <- c("Helsinki",
           "Espoo",


### PR DESCRIPTION
tidyselect 1.1.0 introduces new error:
`i Predicate functions must be wrapped in where().`
Check: https://github.com/r-lib/tidyselect/releases/tag/v1.1.0