### PR TITLE
Fix/accessibility

### DIFF
--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -1,6 +1,7 @@
 library(tidyverse)
 library(config)
 library(here)
+library(cowplot)
 source(here("scripts", "accessibility", "helpers.R"),
        encoding = "utf-8")
 
@@ -108,12 +109,12 @@ results <- results %>%
   mutate(area2 = if_else(area %in% pks, "Pääkaupunkiseutu", "Kehyskunnat"),
          area2 = forcats::as_factor(area2))
 
-# Plot agents ----
+# Plot pks ----
 
-results %>%
+p1 <- results %>%
+  filter(area2 == "Pääkaupunkiseutu") %>%
   ggplot(aes(x = area, y = low_access, fill = scenario)) +
   geom_col(position = position_dodge2()) +
-  facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +
   scale_y_continuous(
     labels = scales::label_number()
   ) +
@@ -124,23 +125,13 @@ results %>%
   geom_abline(slope = 0) +
   labs(y = "asukasta",
        x = NULL,
-       title = "Saavutettavuusköyhien autottomien asukkaiden määrä") +
-  theme_mal_graph() +
-  theme(panel.spacing = unit(2, "lines"))
+       title = "Saavutettavuusköyhien autottomien\nasukkaiden määrä") +
+  theme_mal_graph()
 
-ggsave_graph(
-  here("figures",
-       config::get("projected_scenario"),
-       "low_access_no_car_nr.png"
-  )
-)
-
-# Plot shares ----
-
-results %>%
+p2 <- results %>%
+  filter(area2 == "Pääkaupunkiseutu") %>%
   ggplot(aes(x = area, y = share, fill = scenario)) +
   geom_col(position = position_dodge2()) +
-  facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +
   scale_y_continuous(
     labels = scales::label_percent(accuracy = 1, suffix = "")
   ) +
@@ -151,9 +142,25 @@ results %>%
   geom_abline(slope = 0) +
   labs(y = "%",
        x = NULL,
-       title = "Saavutettavuusköyhien asukkaiden osuus autottomista asukkaista") +
-  theme_mal_graph() +
-  theme(panel.spacing = unit(2, "lines"))
+       title = "Saavutettavuusköyhien asukkaiden\nosuus autottomista asukkaista") +
+  theme_mal_graph()
+
+legend_b <- get_legend(
+  p1 +
+    guides(color = guide_legend(nrow = 1)) +
+    theme(legend.position = "bottom")
+)
+
+prow <- plot_grid(
+  p1 + theme(legend.position = "none"),
+  p2 + theme(legend.position = "none"),
+  align = "vh",
+  axis = "l",
+  hjust = -1,
+  nrow = 1
+)
+
+plot_grid(prow, legend_b, ncol = 1, rel_heights = c(1, .1))
 
 ggsave_graph(
   here("figures",

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -75,23 +75,25 @@ calc_low_access <- function(df, pks, limit_pks, limit_kehys) {
       tour_access_ho < limit_pks,
       tour_access_ho < limit_kehys
     )) %>%
-    group_by(area, is_car_user) %>%
+    group_by(area) %>%
     summarise(nr_agents = n(),
               low_access = sum(low_access, na.rm = TRUE),
               .groups = "drop") %>%
-    mutate(share = low_access / nr_agents) %>%
-    ungroup()
+    mutate(share = low_access / nr_agents)
 }
 
 low_access <- agents %>%
+  filter(!is_car_user) %>%
   calc_low_access(pks, limit_pks, limit_kehys) %>%
   mutate(scenario = config::get("present_name"))
 
 low_access_0 <- agents_0 %>%
+  filter(!is_car_user) %>%
   calc_low_access(pks, limit_pks, limit_kehys) %>%
   mutate(scenario = config::get("baseline_name"))
 
 low_access_1 <- agents_1 %>%
+  filter(!is_car_user) %>%
   calc_low_access(pks, limit_pks, limit_kehys) %>%
   mutate(scenario = config::get("projected_name"))
 
@@ -109,7 +111,6 @@ results <- results %>%
 # Plot agents ----
 
 results %>%
-  filter(!is_car_user) %>%
   ggplot(aes(x = area, y = low_access, fill = scenario)) +
   geom_col(position = position_dodge2()) +
   facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +
@@ -137,7 +138,6 @@ ggsave_graph(
 # Plot shares ----
 
 results %>%
-  filter(!is_car_user) %>%
   ggplot(aes(x = area, y = share, fill = scenario)) +
   geom_col(position = position_dodge2()) +
   facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -123,7 +123,7 @@ results %>%
   geom_abline(slope = 0) +
   labs(y = "asukasta",
        x = NULL,
-       title = "Autottomat asukkaat, joilla kestävien kulkutapojen saavutettavuus\non heikoimpien 5 % joukossa nykytilassa määritettynä") +
+       title = "Saavutettavuusköyhien autottomien asukkaiden määrä") +
   theme_mal_graph() +
   theme(panel.spacing = unit(2, "lines"))
 
@@ -154,7 +154,7 @@ results %>%
   geom_abline(slope = 0) +
   labs(y = "%",
        x = NULL,
-       title = "Osuus autottomista asukkaista, joilla kestävien kulkutapojen saavutettavuus\non heikoimpien 5 % joukossa nykytilassa määritettynä") +
+       title = "Saavutettavuusköyhien autottomien asukkaiden osuus kaikista autottomista asukkaista") +
   theme_mal_graph() +
   theme(panel.spacing = unit(2, "lines"))
 

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -127,14 +127,11 @@ results %>%
   theme_mal_graph() +
   theme(panel.spacing = unit(2, "lines"))
 
-ggsave(
+ggsave_graph(
   here("figures",
        config::get("projected_scenario"),
        "low_access_no_car_nr.png"
-  ),
-  width = dimensions_fig[1],
-  height = dimensions_fig[2],
-  units = "cm"
+  )
 )
 
 # Plot shares ----
@@ -158,12 +155,9 @@ results %>%
   theme_mal_graph() +
   theme(panel.spacing = unit(2, "lines"))
 
-ggsave(
+ggsave_graph(
   here("figures",
        config::get("projected_scenario"),
        "low_access_no_car_share.png"
-  ),
-  width = dimensions_fig[1],
-  height = dimensions_fig[2],
-  units = "cm"
+  )
 )

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -151,7 +151,7 @@ results %>%
   geom_abline(slope = 0) +
   labs(y = "%",
        x = NULL,
-       title = "Saavutettavuusköyhien autottomien asukkaiden osuus kaikista autottomista asukkaista") +
+       title = "Saavutettavuusköyhien asukkaiden osuus autottomista asukkaista") +
   theme_mal_graph() +
   theme(panel.spacing = unit(2, "lines"))
 

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -109,62 +109,64 @@ results <- results %>%
   mutate(area2 = if_else(area %in% pks, "Pääkaupunkiseutu", "Kehyskunnat"),
          area2 = forcats::as_factor(area2))
 
-# Plot pks ----
+# Plot ----
 
-p1 <- results %>%
-  filter(area2 == "Pääkaupunkiseutu") %>%
-  ggplot(aes(x = area, y = low_access, fill = scenario)) +
-  geom_col(position = position_dodge2()) +
-  scale_y_continuous(
-    labels = scales::label_number()
-  ) +
-  scale_x_discrete(
-    labels = scales::label_wrap(5)
-  ) +
-  scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
-  geom_abline(slope = 0) +
-  labs(y = "asukasta",
-       x = NULL,
-       title = "Saavutettavuusköyhien autottomien\nasukkaiden määrä") +
-  theme_mal_graph()
+plot_agents_and_shares <- function(area2) {
+  p1 <- results %>%
+    filter(area2 == {{ area2 }}) %>%
+    ggplot(aes(x = area, y = low_access, fill = scenario)) +
+    geom_col(position = position_dodge2()) +
+    scale_y_continuous(
+      labels = scales::label_number()
+    ) +
+    scale_x_discrete(
+      labels = scales::label_wrap(5)
+    ) +
+    scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
+    geom_abline(slope = 0) +
+    labs(y = "asukasta",
+         x = NULL,
+         title = "Saavutettavuusköyhien autottomien\nasukkaiden määrä") +
+    theme_mal_graph()
 
-p2 <- results %>%
-  filter(area2 == "Pääkaupunkiseutu") %>%
-  ggplot(aes(x = area, y = share, fill = scenario)) +
-  geom_col(position = position_dodge2()) +
-  scale_y_continuous(
-    labels = scales::label_percent(accuracy = 1, suffix = "")
-  ) +
-  scale_x_discrete(
-    labels = scales::label_wrap(5)
-  ) +
-  scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
-  geom_abline(slope = 0) +
-  labs(y = "%",
-       x = NULL,
-       title = "Saavutettavuusköyhien asukkaiden\nosuus autottomista asukkaista") +
-  theme_mal_graph()
+  p2 <- results %>%
+    filter(area2 == {{ area2 }}) %>%
+    ggplot(aes(x = area, y = share, fill = scenario)) +
+    geom_col(position = position_dodge2()) +
+    scale_y_continuous(
+      labels = scales::label_percent(accuracy = 1, suffix = ""),
+      limits = c(0, 0.15)
+    ) +
+    scale_x_discrete(
+      labels = scales::label_wrap(5)
+    ) +
+    scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
+    geom_abline(slope = 0) +
+    labs(y = "%",
+         x = NULL,
+         title = "Saavutettavuusköyhien asukkaiden\nosuus autottomista asukkaista") +
+    theme_mal_graph()
 
-legend_b <- get_legend(
-  p1 +
-    guides(color = guide_legend(nrow = 1)) +
-    theme(legend.position = "bottom")
-)
-
-prow <- plot_grid(
-  p1 + theme(legend.position = "none"),
-  p2 + theme(legend.position = "none"),
-  align = "vh",
-  axis = "l",
-  hjust = -1,
-  nrow = 1
-)
-
-plot_grid(prow, legend_b, ncol = 1, rel_heights = c(1, .1))
-
-ggsave_graph(
-  here("figures",
-       config::get("projected_scenario"),
-       "low_access_no_car_share.png"
+  legend_b <- get_legend(
+    p1 +
+      guides(color = guide_legend(nrow = 1)) +
+      theme(legend.position = "bottom")
   )
-)
+
+  prow <- plot_grid(
+    p1 + theme(legend.position = "none"),
+    p2 + theme(legend.position = "none"),
+    align = "vh",
+    axis = "l",
+    hjust = -1,
+    nrow = 1
+  )
+
+  plot_grid(prow, legend_b, ncol = 1, rel_heights = c(1, .1))
+}
+
+plot_agents_and_shares("Pääkaupunkiseutu")
+ggsave_graph(here::here("figures", config::get("projected_scenario"), "low_access_pks.png"))
+
+plot_agents_and_shares("Kehyskunnat")
+ggsave_graph(here::here("figures", config::get("projected_scenario"), "low_access_kehys.png"))

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -48,35 +48,41 @@ agents_1 <- agents_1 %>%
 # Calculate tour access ----
 
 agents <- agents %>%
-  filter(nr_tours > 0) %>%
-  mutate(tour_access = sustainable_access / nr_tours)
+  # After left_join, if an agent did not make ho tours, nr_tours_ho is NA.
+  filter(!is.na(nr_tours_ho)) %>%
+  filter(nr_tours_ho > 0) %>%
+  mutate(tour_access_ho = sustainable_access_ho / nr_tours_ho)
 
 agents_0 <- agents_0 %>%
-  filter(nr_tours > 0) %>%
-  mutate(tour_access = sustainable_access / nr_tours)
+  # After left_join, if an agent did not make ho tours, nr_tours_ho is NA.
+  filter(!is.na(nr_tours_ho)) %>%
+  filter(nr_tours_ho > 0) %>%
+  mutate(tour_access_ho = sustainable_access_ho / nr_tours_ho)
 
 agents_1 <- agents_1 %>%
-  filter(nr_tours > 0) %>%
-  mutate(tour_access = sustainable_access / nr_tours)
+  # After left_join, if an agent did not make ho tours, nr_tours_ho is NA.
+  filter(!is.na(nr_tours_ho)) %>%
+  filter(nr_tours_ho > 0) %>%
+  mutate(tour_access_ho = sustainable_access_ho / nr_tours_ho)
 
 # Group agents tables ----
 
 limit_pks <- agents %>%
   filter(area %in% pks) %>%
-  summarise(limit = quantile(tour_access, probs = 0.05, na.rm = TRUE)) %>%
+  summarise(limit = quantile(tour_access_ho, probs = 0.05, na.rm = TRUE)) %>%
   pull(limit)
 
 limit_kehys <- agents %>%
   filter(area %in% kehys) %>%
-  summarise(limit = quantile(tour_access, probs = 0.05, na.rm = TRUE)) %>%
+  summarise(limit = quantile(tour_access_ho, probs = 0.05, na.rm = TRUE)) %>%
   pull(limit)
 
 calc_low_access <- function(df, pks, limit_pks, limit_kehys) {
   df %>%
     mutate(low_access = if_else(
       area %in% pks,
-      tour_access < limit_pks,
-      tour_access < limit_kehys
+      tour_access_ho < limit_pks,
+      tour_access_ho < limit_kehys
     )) %>%
     group_by(area) %>%
     summarise(nr_agents = n(),

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -106,33 +106,63 @@ results <- results %>%
   mutate(area2 = if_else(area %in% pks, "Pääkaupunkiseutu", "Kehyskunnat"),
          area2 = forcats::as_factor(area2))
 
-# Plot ----
+# Plot agents ----
 
 results %>%
   filter(!is_car_user) %>%
   ggplot(aes(x = area, y = low_access, fill = scenario)) +
-  geom_bar(
-    stat = "identity",
-    position = "dodge",
-    color = "white",
-    width = 0.8
-  ) +
+  geom_col(position = position_dodge2()) +
   facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +
-  scale_fill_manual(values = hsl_pal("blues")(3)) +
-  theme_fig +
+  scale_y_continuous(
+    labels = scales::label_number()
+  ) +
+  scale_x_discrete(
+    labels = scales::label_wrap(5)
+  ) +
+  scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
   geom_abline(slope = 0) +
-  theme(panel.spacing = unit(2, "lines")) +
-  labs(fill = "Skenaario",
-       y = "Asukkaat",
+  labs(y = "asukasta",
        x = NULL,
-       title = "Autoriippumaton saavutettavuus alle vertailutason",
-       subtitle = "Kotiperäiset muut matkat, joilla ei autoa käytössä")
+       title = "Autottomat asukkaat, joilla kestävien kulkutapojen saavutettavuus\non heikoimpien 5 % joukossa nykytilassa määritettynä") +
+  theme_mal_graph() +
+  theme(panel.spacing = unit(2, "lines"))
 
 ggsave(
   here("figures",
        config::get("projected_scenario"),
-       "low_access_no_car.png"
-       ),
+       "low_access_no_car_nr.png"
+  ),
+  width = dimensions_fig[1],
+  height = dimensions_fig[2],
+  units = "cm"
+)
+
+# Plot shares ----
+
+results %>%
+  filter(!is_car_user) %>%
+  ggplot(aes(x = area, y = share, fill = scenario)) +
+  geom_col(position = position_dodge2()) +
+  facet_wrap( ~ area2, nrow = 1, drop = TRUE, scales = "free_x") +
+  scale_y_continuous(
+    labels = scales::label_percent(accuracy = 1, suffix = "")
+  ) +
+  scale_x_discrete(
+    labels = scales::label_wrap(5)
+  ) +
+  scale_fill_manual(name = NULL, values = hsl_pal("blues")(3)) +
+  geom_abline(slope = 0) +
+  labs(y = "%",
+       x = NULL,
+       title = "Osuus autottomista asukkaista, joilla kestävien kulkutapojen saavutettavuus\non heikoimpien 5 % joukossa nykytilassa määritettynä") +
+  theme_mal_graph() +
+  theme(panel.spacing = unit(2, "lines"))
+
+ggsave(
+  here("figures",
+       config::get("projected_scenario"),
+       "low_access_no_car_share.png"
+  ),
   width = dimensions_fig[1],
   height = dimensions_fig[2],
   units = "cm"


### PR DESCRIPTION
This PR fixes "Autottomien saavutettavuusköyhyys" results. The method is updated so that limits for accessibility poverty are calculated from home-other tours made by all agents, but the results present only those who have no car. Furthermore, plots are updated so that they plot capital region and surrounding region separately, and plots include both number of agents and share of all agents without cars.