### PR TITLE
Fix free speed definition

### DIFF
--- a/scripts/figures/links.R
+++ b/scripts/figures/links.R
@@ -47,7 +47,8 @@ links <- links %>%
   dplyr::mutate(volume_aht = car_leisure_aht + car_work_aht + bus_aht + trailer_truck_aht + truck_aht + van_aht,
                 car_aht = car_work_aht + car_leisure_aht,
                 truck_all_aht = trailer_truck_aht + truck_aht,
-                relative_speed = car_time_pt / car_time_aht) %>%
+                relative_speed = (60 * length / data2) / car_time_aht,
+                relative_speed = dplyr::if_else(relative_speed < 0, NA_real_, relative_speed)) %>%
   # Filter for improved plotting
   dplyr::filter(area != "peripheral")
 

--- a/scripts/figures/links.R
+++ b/scripts/figures/links.R
@@ -48,6 +48,8 @@ links <- links %>%
                 car_aht = car_work_aht + car_leisure_aht,
                 truck_all_aht = trailer_truck_aht + truck_aht,
                 relative_speed = (60 * length / data2) / car_time_aht,
+                # If car_time_aht is -1, the link is disabled for car modes, and
+                # relative speed will be interpreted as NA
                 relative_speed = dplyr::if_else(relative_speed < 0, NA_real_, relative_speed)) %>%
   # Filter for improved plotting
   dplyr::filter(area != "peripheral")

--- a/scripts/figures/single/map_relative-speed.R
+++ b/scripts/figures/single/map_relative-speed.R
@@ -30,7 +30,7 @@ ggplot() +
   ) +
   coord_sf_mal() +
   annotate_map(
-    title = "Aamuhuipputunnin ajonopeus suhteessa päivätunnin ajonopeuteen",
+    title = "Aamuhuipputunnin ajonopeus suhteessa vapaaseen ajonopeuteen",
     subtitle = sprintf("%d %s", scenario_attributes[["year"]], scenario_attributes[["name"]])
   ) +
   theme_mal_map()


### PR DESCRIPTION
Using free speeds on the network, not speeds during day hour. I was considering to do this for OD matrices too (Henkilö- ja tavaraliikenteen kansainväliset ja valtakunnalliset liikenteen solmupisteet 3/3 -> Ruuhkaviiveen osuuden muutos henkilöautoliikenteen matka-ajasta aamuhuipputuntina) but it uses matrices instead of links and matrices do not have the same free speed definition. That is why this fix is done only for link-based results.
