### PR TITLE
Adapt accessibility plots to `R 4.3.0`

### DIFF
--- a/scripts/accessibility/plotting/access_change_age_groups_areas.R
+++ b/scripts/accessibility/plotting/access_change_age_groups_areas.R
@@ -57,7 +57,7 @@ agent_sums %>%
     position = position_dodge2(),
   ) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = scales::label_wrap(5)

--- a/scripts/accessibility/plotting/access_change_income_areas.R
+++ b/scripts/accessibility/plotting/access_change_income_areas.R
@@ -59,7 +59,7 @@ agent_sums %>%
     position = position_dodge2()
   ) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = scales::label_wrap(5)

--- a/scripts/accessibility/plotting/access_gap_ages_areas.R
+++ b/scripts/accessibility/plotting/access_gap_ages_areas.R
@@ -82,7 +82,7 @@ gap %>%
   geom_col(fill = "white", position = position_dodge2()) +
   geom_col(aes(fill = age_group, alpha = scenario), position = position_dodge2()) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = NULL

--- a/scripts/accessibility/plotting/access_gap_areas.R
+++ b/scripts/accessibility/plotting/access_gap_areas.R
@@ -92,6 +92,9 @@ gap %>%
     color = "white",
     width = 0.8
   ) +
+  scale_y_continuous(
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
+  ) +
   scale_fill_manual(values = hsl_pal("blues")(3)) +
   theme_fig +
   geom_abline(slope = 0) +

--- a/scripts/accessibility/plotting/access_gap_areas.R
+++ b/scripts/accessibility/plotting/access_gap_areas.R
@@ -99,7 +99,8 @@ gap %>%
        y = "eur / kiertomatka",
        x = NULL,
        title = "Saavutettavuusero suhteessa seudun keskiarvoon",
-       subtitle = "Kotiperäiset työmatkat")
+       subtitle = "Kotiperäiset työmatkat") +
+  theme(plot.background = element_rect(fill = "#FFFFFF", color = "#FFFFFF"))
 
 ggsave(
   here("figures",

--- a/scripts/accessibility/plotting/access_gap_income_areas.R
+++ b/scripts/accessibility/plotting/access_gap_income_areas.R
@@ -87,7 +87,7 @@ gap %>%
   geom_col(fill = "white", position = position_dodge2()) +
   geom_col(aes(fill = income_group, alpha = scenario), position = position_dodge2()) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = NULL

--- a/scripts/accessibility/plotting/cost_change_age_group.R
+++ b/scripts/accessibility/plotting/cost_change_age_group.R
@@ -48,7 +48,7 @@ agent_sums %>%
     position = position_dodge2(),
   ) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = scales::label_wrap(5)

--- a/scripts/accessibility/plotting/cost_change_areas.R
+++ b/scripts/accessibility/plotting/cost_change_areas.R
@@ -48,7 +48,7 @@ agent_sums %>%
   ) +
   geom_abline(slope = 0) +
   scale_y_continuous(
-    labels = scales::label_number(accuracy = 1),
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01),
     expand = expansion(mult = c(0.025, 0.1))
   ) +
   scale_x_discrete(

--- a/scripts/accessibility/plotting/cost_change_income.R
+++ b/scripts/accessibility/plotting/cost_change_income.R
@@ -51,7 +51,7 @@ agent_sums %>%
     position = position_dodge2()
   ) +
   scale_y_continuous(
-    labels = scales::label_number(decimal.mark = ",")
+    labels = scales::label_number(decimal.mark = ",", accuracy = 0.01)
   ) +
   scale_x_discrete(
     labels = scales::label_wrap(5)

--- a/scripts/accessibility/plotting/low_access_no_car.R
+++ b/scripts/accessibility/plotting/low_access_no_car.R
@@ -161,7 +161,8 @@ plot_agents_and_shares <- function(area2) {
     nrow = 1
   )
 
-  plot_grid(prow, legend_b, ncol = 1, rel_heights = c(1, .1))
+  plot_grid(prow, legend_b, ncol = 1, rel_heights = c(1, .1)) +
+    theme(plot.background = element_rect(fill = "#FFFFFF", color = "#FFFFFF"))
 }
 
 plot_agents_and_shares("Pääkaupunkiseutu")

--- a/scripts/accessibility/plotting/present_cost_income.R
+++ b/scripts/accessibility/plotting/present_cost_income.R
@@ -101,7 +101,8 @@ results %>%
         "Liikkumisen ja asumisen suorat kustannukset: ",
         config::get("present_name")
       )
-  )
+  ) +
+  theme(plot.background = element_rect(fill = "#FFFFFF", color = "#FFFFFF"))
 
 ggsave(
   here(


### PR DESCRIPTION
This PR introduces some visual fixes and improvements I notices when comparing how changes from #69 affected accessibility scripts. The results stayd the same. Fixes are:
- give all plots white background (either due to R or Windows, the default was transparent)
- have all monetary costs have sccuracy of 0.01

This PR is ready for review.